### PR TITLE
Using the proper keys for mqtt credentials

### DIFF
--- a/MqttPublisher/src/main/res/xml/settings.xml
+++ b/MqttPublisher/src/main/res/xml/settings.xml
@@ -47,16 +47,16 @@
 
         <EditTextPreference
             android:defaultValue="guest"
-            android:key="username"
+            android:key="mqtt_username"
             android:summary="@string/user_name_sum"
-            android:title="@string/user_name"/>
+            android:title="@string/user_name" />
 
         <EditTextPreference
             android:defaultValue="guest"
-            android:key="password"
+            android:key="mqtt_password"
             android:password="true"
             android:summary="@string/password_sum"
-            android:title="@string/password"/>
+            android:title="@string/password" />
 
         <ListPreference
             android:defaultValue="0"


### PR DESCRIPTION
Followup from https://github.com/fr3ts0n/AndrOBD-Plugin/issues/2

I tracked down the issues with mqtt credentials issues. For the username and password fields, the settings used `user_name` and `password`, while the `MqttPlugin` plugin expected `mqtt_username` and `mqtt_password`.